### PR TITLE
Add caching functionality for dataset generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# cache
+.cache/

--- a/README.md
+++ b/README.md
@@ -91,9 +91,15 @@ Features:
    - Download your dataset as CSV or SQL Inserts.
    - Click "Start Metabase" to spin up Metabase in Docker.
    - Once Metabase is ready, click "Open Metabase" to explore your data.
+     - In Metabase, use the ["Upload Data" feature](https://www.metabase.com/docs/latest/exploration-and-organization/uploads) to analyze your CSV files
+     - Or [connect to your own database](https://www.metabase.com/docs/latest/databases/connecting) where you've loaded the data
    - When done, click "Stop Metabase" to shut down and clean up Docker containers.
 
 ## How It Works
+
+The dataset generator uses a two-stage process to create realistic business data. First, it leverages large language models to
+generate detailed data specifications based on your business type and parameters. Then, it uses these specifications to create
+unlimited amounts of realistic data locally.
 
 - When you preview a dataset, the app uses LiteLLM (which can route to OpenAI, Anthropic, Google, etc.) to generate a detailed data spec (schema, business rules, event logic) for your chosen business type and parameters.
 - All actual data rows are generated locally using Faker, based on the LLM-generated spec.
@@ -112,16 +118,7 @@ _The above costs and behavior are based on testing with the OpenAI GPT-4o model.
 - **You only pay for the preview/spec generation** (e.g., ~$0.05 per preview with OpenAI GPT-4o)
 - **All downloads use the same columns/spec, just with more rows, and are free**
 
-## Using Metabase
-
-When you click "Start Metabase", it will launch Metabase in a Docker container. Once ready:
-
-1. Click "Open Metabase" to access the Metabase interface
-2. Follow Metabase's setup process
-3. To analyze your generated data:
-   - Use the CSV export feature to download your dataset
-   - In Metabase, use the ["Upload Data" feature](https://www.metabase.com/docs/latest/exploration-and-organization/uploads) to analyze your CSV files
-   - Or [connect to your own database](https://www.metabase.com/docs/latest/databases/connecting) where you've loaded the data
+**Caching:** After your first preview, the app remembers your data structure. If you preview the same business type and settings again, it reuses that structure (free) instead of generating a new one. This saves money and time. You'll see "Using cached spec" in the terminal when this happens. Check cache stats: `curl http://localhost:3000/api/cache/stats` or clear: `curl -X DELETE http://localhost:3000/api/cache/clear`.
 
 ## Project Structure
 

--- a/app/api/cache/clear/route.ts
+++ b/app/api/cache/clear/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { clearCache } from "@/lib/cache";
+
+export async function DELETE() {
+  try {
+    const deletedCount = await clearCache();
+
+    return NextResponse.json({
+      success: true,
+      message: `Cleared ${deletedCount} cache files`,
+      deletedCount,
+    });
+  } catch (error) {
+    console.error("Error clearing cache:", error);
+    return NextResponse.json(
+      { error: "Failed to clear cache" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/cache/stats/route.ts
+++ b/app/api/cache/stats/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { getCacheStats } from "@/lib/cache";
+
+export async function GET() {
+  try {
+    const stats = await getCacheStats();
+
+    return NextResponse.json({
+      success: true,
+      stats: {
+        ...stats,
+        oldestFile: stats.oldestFile
+          ? new Date(stats.oldestFile).toISOString()
+          : undefined,
+        newestFile: stats.newestFile
+          ? new Date(stats.newestFile).toISOString()
+          : undefined,
+      },
+    });
+  } catch (error) {
+    console.error("Error getting cache stats:", error);
+    return NextResponse.json(
+      { error: "Failed to get cache stats" },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,185 @@
+import fs from "fs/promises";
+import path from "path";
+import { createHash } from "crypto";
+import { GenerateSpecPromptParams } from "./spec-prompts";
+
+const CACHE_DIR = path.join(process.cwd(), ".cache");
+const CACHE_CONFIG = {
+  maxSizeMB: 100,
+  maxFiles: 1000,
+  maxAgeDays: 30,
+  cleanupInterval: 24 * 60 * 60 * 1000, // 24 hours
+};
+
+let lastCleanup = Date.now();
+
+// Generate cache key from parameters
+export function generateCacheKey(params: GenerateSpecPromptParams): string {
+  return createHash("sha256").update(JSON.stringify(params)).digest("hex");
+}
+
+// Get cached spec if it exists
+export async function getCachedSpec(
+  params: GenerateSpecPromptParams
+): Promise<any | null> {
+  try {
+    const key = generateCacheKey(params);
+    const filePath = path.join(CACHE_DIR, `${key}.json`);
+
+    const data = await fs.readFile(filePath, "utf8");
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
+}
+
+// Cache a spec
+export async function cacheSpec(
+  params: GenerateSpecPromptParams,
+  spec: any
+): Promise<void> {
+  try {
+    const key = generateCacheKey(params);
+    const filePath = path.join(CACHE_DIR, `${key}.json`);
+
+    // Ensure cache directory exists
+    await fs.mkdir(CACHE_DIR, { recursive: true });
+
+    // Write spec to cache
+    await fs.writeFile(filePath, JSON.stringify(spec));
+
+    // Check if cleanup is needed
+    if (Date.now() - lastCleanup > CACHE_CONFIG.cleanupInterval) {
+      await cleanupCache();
+      lastCleanup = Date.now();
+    }
+  } catch (error) {
+    console.error("Failed to cache spec:", error);
+  }
+}
+
+// Clean up old cache files
+export async function cleanupCache(): Promise<void> {
+  try {
+    // Ensure cache directory exists
+    await fs.mkdir(CACHE_DIR, { recursive: true });
+
+    const files = await fs.readdir(CACHE_DIR);
+    const fileStats = await Promise.all(
+      files.map(async (file) => {
+        if (!file.endsWith(".json")) return null;
+
+        const filePath = path.join(CACHE_DIR, file);
+        const stats = await fs.stat(filePath);
+        return { file, size: stats.size, mtime: stats.mtime };
+      })
+    );
+
+    // Filter out null entries and sort by last accessed (oldest first)
+    const validFiles = fileStats
+      .filter(Boolean)
+      .sort((a, b) => a!.mtime.getTime() - b!.mtime.getTime());
+
+    // Calculate total size
+    const totalSizeMB =
+      validFiles.reduce((sum, file) => sum + file!.size, 0) / (1024 * 1024);
+    const cutoff = Date.now() - CACHE_CONFIG.maxAgeDays * 24 * 60 * 60 * 1000;
+
+    let deletedCount = 0;
+
+    // Delete files if over limits or too old
+    if (
+      totalSizeMB > CACHE_CONFIG.maxSizeMB ||
+      validFiles.length > CACHE_CONFIG.maxFiles
+    ) {
+      const filesToDelete = validFiles.slice(
+        0,
+        Math.floor(validFiles.length * 0.3)
+      ); // Delete 30%
+
+      for (const file of filesToDelete) {
+        await fs.unlink(path.join(CACHE_DIR, file!.file));
+        deletedCount++;
+      }
+    } else {
+      // Delete old files
+      for (const file of validFiles) {
+        if (file!.mtime.getTime() < cutoff) {
+          await fs.unlink(path.join(CACHE_DIR, file!.file));
+          deletedCount++;
+        }
+      }
+    }
+
+    if (deletedCount > 0) {
+      console.log(`Cache cleanup: deleted ${deletedCount} files`);
+    }
+  } catch (error) {
+    console.error("Cache cleanup failed:", error);
+  }
+}
+
+// Get cache statistics
+export async function getCacheStats(): Promise<{
+  fileCount: number;
+  totalSizeMB: number;
+  oldestFile?: number;
+  newestFile?: number;
+}> {
+  try {
+    // Ensure cache directory exists
+    await fs.mkdir(CACHE_DIR, { recursive: true });
+
+    const files = await fs.readdir(CACHE_DIR);
+    const jsonFiles = files.filter((file) => file.endsWith(".json"));
+
+    if (jsonFiles.length === 0) {
+      return { fileCount: 0, totalSizeMB: 0 };
+    }
+
+    const stats = await Promise.all(
+      jsonFiles.map(async (file) => {
+        const filePath = path.join(CACHE_DIR, file);
+        const stat = await fs.stat(filePath);
+        return { file, size: stat.size, mtime: stat.mtime };
+      })
+    );
+
+    const totalSizeMB =
+      stats.reduce((sum, file) => sum + file.size, 0) / (1024 * 1024);
+    const timestamps = stats.map((s) => s.mtime.getTime());
+
+    return {
+      fileCount: stats.length,
+      totalSizeMB: Math.round(totalSizeMB * 100) / 100,
+      oldestFile: Math.min(...timestamps),
+      newestFile: Math.max(...timestamps),
+    };
+  } catch (error) {
+    console.error("Failed to get cache stats:", error);
+    return { fileCount: 0, totalSizeMB: 0 };
+  }
+}
+
+// Clear all cache files
+export async function clearCache(): Promise<number> {
+  try {
+    // Ensure cache directory exists
+    await fs.mkdir(CACHE_DIR, { recursive: true });
+
+    const files = await fs.readdir(CACHE_DIR);
+    let deletedCount = 0;
+
+    for (const file of files) {
+      if (file.endsWith(".json")) {
+        await fs.unlink(path.join(CACHE_DIR, file));
+        deletedCount++;
+      }
+    }
+
+    return deletedCount;
+  } catch (error) {
+    console.error("Failed to clear cache:", error);
+    return 0;
+  }
+}


### PR DESCRIPTION
- Implement cache system to store and retrieve generated specs, reducing LLM calls and improving performance.
- Add API routes for clearing cache and retrieving cache statistics.
- Update README.md to reflect caching features and usage instructions.
- Modify dataset generation logic to utilize cached specs when available.